### PR TITLE
Sprint player | Fix normalise angle horizontal

### DIFF
--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: mcogne-- <mcogne--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 18:14:34 by mcogne--          #+#    #+#             */
-/*   Updated: 2025/01/24 17:48:33 by mcogne--         ###   ########.fr       */
+/*   Updated: 2025/01/24 18:48:38 by mcogne--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,7 @@
 # define RENDER_SIZE_2D 32
 
 # define MOVE_SPEED 0.05
+# define SPRINT_SPEED 0.08
 # define ANGLE_SPEED 4
 # define MOUSE_SPEED 0.02
 
@@ -96,7 +97,7 @@ short	ft_put_pixel_in_img(t_mlx *mlx, t_pos pos, int color);
 int		loop_hook_handler(t_env *env);
 
 /* GAME */
-short	update_player_angle(t_env *env, float angle_h, float angle_v);
+short	update_player_angle(t_map *map, float angle_h, float angle_v);
 short	handler_move_player(t_env *env);
 
 /*******************************/
@@ -111,8 +112,8 @@ short	is_map_line(char *line);
 short	is_texture_line(char *line);
 char	*get_msg_error(size_t err);
 int		exit_user(t_env *env);
-double	normalize_angle_horizontal(double angle);
-double	normalize_angle_vertical(double angle);
+double	normalize_angle_h(double angle);
+double	normalize_angle_v(double angle);
 
 /*******************************/
 /*          DEBUG MODE         */

--- a/include/key.h
+++ b/include/key.h
@@ -6,7 +6,7 @@
 /*   By: mcogne-- <mcogne--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 22:17:05 by mcogne--          #+#    #+#             */
-/*   Updated: 2025/01/24 16:33:49 by mcogne--         ###   ########.fr       */
+/*   Updated: 2025/01/24 18:34:26 by mcogne--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,9 @@ typedef enum e_key
 	KEY_LEFT = 65361,
 	KEY_RIGHT = 65363,
 	KEY_TOP = 65362,
-	KEY_BOT = 65364
+	KEY_BOT = 65364,
+	KEY_SHIFT = 65505,
+	KEY_CAPSLOCK = 65509
 }	t_key;
 
 typedef enum e_key_mouse

--- a/include/struct.h
+++ b/include/struct.h
@@ -6,7 +6,7 @@
 /*   By: mcogne-- <mcogne--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/15 19:34:09 by mcogne--          #+#    #+#             */
-/*   Updated: 2025/01/24 18:03:05 by mcogne--         ###   ########.fr       */
+/*   Updated: 2025/01/24 18:17:52 by mcogne--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ typedef struct s_event
 	short			move_back;
 	short			move_right;
 	short			move_left;
+	short			move_sprint;
 	short			angle_v_right;
 	short			angle_v_left;
 	short			angle_h_up;

--- a/src/exec/game/move_placer.c
+++ b/src/exec/game/move_placer.c
@@ -6,7 +6,7 @@
 /*   By: mcogne-- <mcogne--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/18 22:42:25 by mcogne--          #+#    #+#             */
-/*   Updated: 2025/01/24 17:55:14 by mcogne--         ###   ########.fr       */
+/*   Updated: 2025/01/24 18:48:23 by mcogne--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,12 +41,12 @@
 // 	return (0);
 // }
 
-short	update_player_angle(t_env *env, float angle_h, float angle_v)
+short	update_player_angle(t_map *map, float angle_h, float angle_v)
 {
-	env->map->player.pos.angle_h += angle_h * ANGLE_SPEED;
-	env->map->player.pos.angle_v += angle_v * ANGLE_SPEED;
-	normalize_angle_horizontal(env->map->player.pos.angle_h);
-	normalize_angle_vertical(env->map->player.pos.angle_v);
+	map->player.pos.angle_h += angle_h * ANGLE_SPEED;
+	map->player.pos.angle_v += angle_v * ANGLE_SPEED;
+	map->player.pos.angle_h = normalize_angle_h(map->player.pos.angle_h);
+	map->player.pos.angle_v = normalize_angle_v(map->player.pos.angle_v);
 	return (0);
 }
 
@@ -54,9 +54,13 @@ static short	update_player_position(t_env *env, float x, float y)
 {
 	float	new_x;
 	float	new_y;
+	float	speed;
 
-	new_x = env->map->player.pos.x + x * MOVE_SPEED;
-	new_y = env->map->player.pos.y + y * MOVE_SPEED;
+	speed = MOVE_SPEED;
+	if (env->event->move_sprint)
+		speed = SPRINT_SPEED;
+	new_x = env->map->player.pos.x + x * speed;
+	new_y = env->map->player.pos.y + y * speed;
 	if (env->map->grid[(int)floor(new_x)][(int)floor(new_y)] == '1')
 		return (0);
 	env->map->player.pos.x = new_x;
@@ -79,12 +83,12 @@ short	handler_move_player(t_env *env)
 		update_player_position(env, -cos(env->map->player.pos.angle_h * M_PI
 				/ 180), -sin(env->map->player.pos.angle_h * M_PI / 180));
 	if (env->event->angle_v_left)
-		update_player_angle(env, -1, 0);
+		update_player_angle(env->map, -1, 0);
 	if (env->event->angle_v_right)
-		update_player_angle(env, 1, 0);
+		update_player_angle(env->map, 1, 0);
 	if (env->event->angle_h_up)
-		update_player_angle(env, 0, -1);
+		update_player_angle(env->map, 0, -1);
 	if (env->event->angle_h_down)
-		update_player_angle(env, 0, 1);
+		update_player_angle(env->map, 0, 1);
 	return (0);
 }

--- a/src/exec/mlx/mlx_events.c
+++ b/src/exec/mlx/mlx_events.c
@@ -6,7 +6,7 @@
 /*   By: mcogne-- <mcogne--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/18 15:45:00 by mcogne--          #+#    #+#             */
-/*   Updated: 2025/01/24 17:50:48 by mcogne--         ###   ########.fr       */
+/*   Updated: 2025/01/24 18:49:12 by mcogne--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ static int	move_mouse_event(int pos_h, int pos_v, t_env *env)
 		return (0);
 	}
 	if (last_pos_h != pos_h || last_pos_v != pos_v)
-		update_player_angle(env, (last_pos_h - pos_h) * -1 * MOUSE_SPEED,
+		update_player_angle(env->map, (last_pos_h - pos_h) * -1 * MOUSE_SPEED,
 			(last_pos_v - pos_v) * -1 * MOUSE_SPEED);
 	last_pos_h = pos_h;
 	last_pos_v = pos_v;
@@ -74,6 +74,8 @@ static int	key_release(int keycode, t_env *env)
 		env->event->angle_h_up = 0;
 	else if (keycode == KEY_BOT)
 		env->event->angle_h_down = 0;
+	else if (keycode == KEY_SHIFT || keycode == KEY_CAPSLOCK)
+		env->event->move_sprint = 0;
 	return (0);
 }
 
@@ -97,6 +99,8 @@ static int	key_press(int keycode, t_env *env)
 		env->event->angle_h_up = 1;
 	else if (keycode == KEY_BOT)
 		env->event->angle_h_down = 1;
+	else if (keycode == KEY_SHIFT || keycode == KEY_CAPSLOCK)
+		env->event->move_sprint = 1;
 	return (0);
 }
 

--- a/src/exec/ray_casting/ray_casting.c
+++ b/src/exec/ray_casting/ray_casting.c
@@ -6,7 +6,7 @@
 /*   By: mcogne-- <mcogne--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/21 09:35:50 by achaisne          #+#    #+#             */
-/*   Updated: 2025/01/24 17:48:40 by mcogne--         ###   ########.fr       */
+/*   Updated: 2025/01/24 18:43:41 by mcogne--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,7 @@ t_render	*send_ray(int ray_index_v, int ray_index_h, t_player *player,
 {
 	t_ray	ray;
 
-	ray.angle_h = normalize_angle_horizontal((player->pos.angle_h - (HFVH / 2)
+	ray.angle_h = normalize_angle_h((player->pos.angle_h - (HFVH / 2)
 				+ HFVH * (ray_index_h / ((RESH / 2) - 1))) * -1);
 	ray.angle_v = (player->pos.angle_v - (HFVV / 2) + HFVV * (ray_index_v
 				/ ((RESV / 2) - 1))) * -1;

--- a/src/utils/normalize_angle.c
+++ b/src/utils/normalize_angle.c
@@ -1,27 +1,27 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   dwa.c                                              :+:      :+:    :+:   */
+/*   normalize_angle.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: mcogne-- <mcogne--@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/24 17:41:29 by mcogne--          #+#    #+#             */
-/*   Updated: 2025/01/24 17:43:06 by mcogne--         ###   ########.fr       */
+/*   Updated: 2025/01/24 18:43:41 by mcogne--         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
 
-double	normalize_angle_vertical(double angle)
+double	normalize_angle_v(double angle)
 {
-	if (angle < 0)
-		angle += 35;
-	else if (angle >= 35)
-		angle -= 35;
+	if (angle < -45)
+		angle = -45;
+	else if (angle >= 45)
+		angle = 45;
 	return (angle);
 }
 
-double	normalize_angle_horizontal(double angle)
+double	normalize_angle_h(double angle)
 {
 	if (angle < 0)
 		angle += 360.0;


### PR DESCRIPTION
This pull request includes multiple changes to the `cub3d` project, focusing on adding sprint functionality, renaming angle normalization functions, and updating key handling. The most important changes include defining sprint speed, modifying player movement functions, and updating key event handling.

### Sprint Functionality:
* Added `SPRINT_SPEED` definition in `include/cub3d.h`.
* Added `move_sprint` to `s_event` struct in `include/struct.h`.
* Updated `update_player_position` to account for sprint speed in `src/exec/game/move_placer.c`.

### Angle Normalization:
* Renamed `normalize_angle_horizontal` to `normalize_angle_h` and `normalize_angle_vertical` to `normalize_angle_v` in `include/cub3d.h`.
* Updated corresponding function names in `src/utils/normalize_angle.c`.

### Key Handling:
* Added `KEY_SHIFT` and `KEY_CAPSLOCK` definitions in `include/key.h`.
* Updated `key_press` and `key_release` functions to handle sprint keys in `src/exec/mlx/mlx_events.c` [[1]](diffhunk://#diff-f614774816075827013766cee32dc34d95d172d26a14cb2b6348b7e8bc6fc58eR102-R103) [[2]](diffhunk://#diff-f614774816075827013766cee32dc34d95d172d26a14cb2b6348b7e8bc6fc58eR77-R78).

### Player Movement:
* Modified `update_player_angle` to use `t_map` instead of `t_env` in `include/cub3d.h` and `src/exec/game/move_placer.c` [[1]](diffhunk://#diff-10c6402257c16cd6c13987627385615ddf2e53382b7c802bb4715e4dd7398510L99-R100) [[2]](diffhunk://#diff-97f3e785363d1e3dd93987497b7c774adf29455e5255541c843e5b67fad61309L44-R63).
* Updated `handler_move_player` to use `t_map` in `src/exec/game/move_placer.c`.

### Miscellaneous:
* Updated file headers with new timestamps in multiple files [[1]](diffhunk://#diff-10c6402257c16cd6c13987627385615ddf2e53382b7c802bb4715e4dd7398510L9-R9) [[2]](diffhunk://#diff-3b5e4f062b8f84db926cf6436ced34bb87a66e02a3e4729971670904897ee2d1L9-R9) [[3]](diffhunk://#diff-1ac144582eab5908acc61a0a76a4302f4ec133c7ffb46589ea114f477ace7b4bL9-R9) [[4]](diffhunk://#diff-97f3e785363d1e3dd93987497b7c774adf29455e5255541c843e5b67fad61309L9-R9) [[5]](diffhunk://#diff-f614774816075827013766cee32dc34d95d172d26a14cb2b6348b7e8bc6fc58eL9-R9) [[6]](diffhunk://#diff-dbe8dc985a0568c47565659c466aca6704654d83ff702893d9b359ec09925c3cL9-R9).